### PR TITLE
Add Oryon scan workflow

### DIFF
--- a/.github/workflows/oryon-scan.yml
+++ b/.github/workflows/oryon-scan.yml
@@ -1,0 +1,62 @@
+name: Oryon Security Scan
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  oryon:
+    name: Oryon scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: repo
+
+      - name: Checkout Oryon Action
+        uses: actions/checkout@v4
+        with:
+          repository: Guayamose/oryon-action
+          ref: main
+          path: action
+          ssh-key: ${{ secrets.ORYON_ACTION_DEPLOY_KEY }}
+
+      - name: Normalize repository identity
+        working-directory: repo
+        run: |
+          repo="${GITHUB_REPOSITORY,,}"
+          git remote set-url origin "git@github.com:${repo}.git"
+
+      - name: Run Oryon scan
+        id: oryon
+        uses: ./action
+        with:
+          backend-url: https://dashboard.oryontechnology.com
+          workspace: repo
+          out-dir: .oryon
+          upload: "true"
+          ai: "true"
+          report: none
+          sarif: "true"
+          fail-on: none
+        env:
+          ORYON_CI_TOKEN: ${{ secrets.ORYON_CI_TOKEN }}
+          ORYON_CLIENT_SECRET: ${{ secrets.ORYON_CLIENT_SECRET }}
+
+      - name: Upload Oryon artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oryon-security-scan
+          path: repo/.oryon/
+          include-hidden-files: true
+          if-no-files-found: warn


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs the Oryon scanner on push, pull request, and manual dispatch.

What changed:
- checks out the Foodly repository into `repo/` so the scanner only scans application code;
- checks out the private `Guayamose/oryon-action` repository through a read-only deploy key;
- normalizes the repository remote so the runner matches the existing Oryon `Project-Foodly` binding;
- runs Oryon with upload and AI enabled;
- uploads JSON/SARIF/Markdown artifacts from `repo/.oryon/`.

Validation:
- workflow run `25563022777` completed successfully;
- Oryon uploaded scan `243` to project `3`;
- GitHub artifact `oryon-security-scan` uploaded successfully.
